### PR TITLE
Pass along the actual taxomony term

### DIFF
--- a/search_node_page.module
+++ b/search_node_page.module
@@ -995,6 +995,8 @@ function search_node_page_build_search_box($configuration = array()) {
         foreach (taxonomy_get_tree($vocab->vid) as $term) {
           $terms[$term->name] = array(
             'value' => $term->name,
+            // Pass along the actual term.
+            'term' => $term,
           );
         }
 


### PR DESCRIPTION
In order to handle hierarchical taxonomy terms, we need to pass the actual term on to whoever renders the terms.
